### PR TITLE
Add value to optionally turn off init-job

### DIFF
--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initjob.enabled -}}
 kind: Job
 apiVersion: batch/v1
 metadata:
@@ -92,3 +93,4 @@ spec:
           hostPath:
             path: /etc/kubernetes/
             type: DirectoryOrCreate
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,3 +47,5 @@ storageclass:
     name: open-local-mountpoint-ssd
   mountpoint_hdd:
     name: open-local-mountpoint-hdd
+initjob:
+  enabled: true


### PR DESCRIPTION
On my single node cluster, the init-job is permanently pending due to a node affinity issue (my node is the master).

The init-job makes many assumptions about the setup open-local is running on, and should be optional in case it's not needed.