### PR TITLE
add fstype in storage class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ IMAGE_NAME=ack-agility-registry.cn-shanghai.cr.aliyuncs.com/ecp_builder/${NAME}
 MAIN_FILE=./cmd/main.go
 LD_FLAGS=-ldflags "-X '${GO_PACKAGE}/pkg/version.GitCommit=$(GIT_COMMIT)' -X '${GO_PACKAGE}/pkg/version.Version=$(VERSION)' -X 'main.VERSION=$(VERSION)' -X 'main.COMMITID=$(GIT_COMMIT)'"
 GIT_COMMIT=$(shell git rev-parse HEAD)
-VERSION=v0.5.0
+VERSION=v0.5.1-dev
 
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 CRD_VERSION=v1alpha1

--- a/helm/templates/storage-class.yaml
+++ b/helm/templates/storage-class.yaml
@@ -5,6 +5,7 @@ metadata:
 provisioner: {{ .Values.driver }}
 parameters:
   volumeType: "LVM"
+  csi.storage.k8s.io/fstype: ext4
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
@@ -27,6 +28,7 @@ metadata:
   name: {{ .Values.storageclass.lvm_io.name }}
 provisioner: {{ .Values.driver }}
 parameters:
+  csi.storage.k8s.io/fstype: ext4
   volumeType: "LVM"
   bps: "1048576"
   iops: "1024"
@@ -40,6 +42,7 @@ metadata:
   name: {{ .Values.storageclass.device_hdd.name }}
 provisioner: {{ .Values.driver }}
 parameters:
+  csi.storage.k8s.io/fstype: ext4
   volumeType: Device
   mediaType: hdd
 reclaimPolicy: Delete
@@ -52,6 +55,7 @@ metadata:
   name: {{ .Values.storageclass.device_ssd.name }}
 provisioner: {{ .Values.driver }}
 parameters:
+  csi.storage.k8s.io/fstype: ext4
   volumeType: Device
   mediaType: sdd
 reclaimPolicy: Delete
@@ -64,8 +68,9 @@ metadata:
    name: {{ .Values.storageclass.mountpoint_hdd.name }}
 provisioner: {{ .Values.driver }}
 parameters:
-    volumeType: MountPoint
-    mediaType: hdd
+  csi.storage.k8s.io/fstype: ext4
+  volumeType: MountPoint
+  mediaType: hdd
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -75,7 +80,8 @@ metadata:
    name: {{ .Values.storageclass.mountpoint_ssd.name }}
 provisioner: {{ .Values.driver }}
 parameters:
-    volumeType: MountPoint
-    mediaType: ssd
+  csi.storage.k8s.io/fstype: ext4
+  volumeType: MountPoint
+  mediaType: ssd
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/pkg/csi/nodeserver.go
+++ b/pkg/csi/nodeserver.go
@@ -126,8 +126,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		volumeType = req.VolumeContext[VolumeTypeTag]
 	}
 
-	ephemeralVolume := req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == "true" ||
-		req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == ""
+	ephemeralVolume := req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == "true"
 	if ephemeralVolume {
 		_, vgNameExist := req.VolumeContext[localtype.ParamVGName]
 		if !vgNameExist {


### PR DESCRIPTION
- [bugfix] add fstype in storage class to support [configure volume permission and ownership change policy for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
- [bugfix] misidentifying persistent volume type as ephemeral volume