### PR TITLE
Allow CSI plugins to specify --kubeconfig/--master

### DIFF
--- a/cmd/csi/csi.go
+++ b/cmd/csi/csi.go
@@ -58,7 +58,7 @@ func Start(opt *csiOption) error {
 	// GRPC server to provide volume manage
 	go lvmserver.Start(opt.LVMDPort)
 
-	cfg, err := clientcmd.BuildConfigFromFlags("", "")
+	cfg, err := clientcmd.BuildConfigFromFlags(opt.Master, opt.Kubeconfig)
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}

--- a/cmd/csi/options.go
+++ b/cmd/csi/options.go
@@ -22,6 +22,8 @@ import (
 )
 
 type csiOption struct {
+	Master                  string
+	Kubeconfig              string
 	Endpoint                string
 	NodeID                  string
 	Driver                  string
@@ -35,6 +37,8 @@ type csiOption struct {
 }
 
 func (option *csiOption) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&option.Kubeconfig, "kubeconfig", option.Kubeconfig, "Path to the kubeconfig file to use.")
+	fs.StringVar(&option.Master, "master", option.Master, "URL/IP for master.")
 	fs.StringVar(&option.Endpoint, "endpoint", csi.DefaultEndpoint, "the endpointof CSI")
 	fs.StringVar(&option.NodeID, "nodeID", "", "the id of node")
 	fs.StringVar(&option.Driver, "driver", csi.DefaultDriverName, "the name of CSI driver")


### PR DESCRIPTION
Add `--kubeconfig`/`--master` flags for CSI plugins, like controller and scheduler-extender, for initializing kube client.