### PR TITLE
[Helm]modify init job for support k8s version >= 1.23.x

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -13,3 +13,18 @@ labels:
 {{ toYaml .Values.customLabels | indent 2 -}}
   {{- end }}
 {{- end -}}
+
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version -}}
+{{- end -}}
+
+{{/* set k8s scheduler init job Version */}}
+{{/* see https://github.com/kubernetes/kubernetes/pull/105424 */}}
+{{- define "init.job.version" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.23-0" (include "kubeVersion" .)) -}}
+      {{- print "new" -}}
+  {{- else -}}
+    {{- print "old" -}}
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -1,3 +1,5 @@
+{{- $job_version := include "init.job.version" . }}
+
 {{- if .Values.extender.init_job }}
 kind: Job
 apiVersion: batch/v1
@@ -43,12 +45,47 @@ spec:
         - sh
         - "-c"
         - |
+ {{ if eq $job_version "new" }}
             set -ex
-
             sleep 4
 
-            echo "generating scheduler-policy-config.json..."
+            echo "generating kubeScheduler-config.yml..."
 
+            cat >/etc/kubernetes/kubeScheduler-config.yml  <<EOF
+            apiVersion: kubescheduler.config.k8s.io/v1
+            kind: KubeSchedulerConfiguration
+            clientConnection:
+              kubeconfig: /etc/kubernetes/scheduler.conf
+            extenders:
+              - urlPrefix: 'http://{{ .Values.extender.name }}.{{.Values.namespace}}:23000/scheduler'
+                filterVerb: predicates
+                prioritizeVerb: priorities
+                preemptVerb: ''
+                bindVerb: ''
+                weight: 10
+                enableHTTPS: false
+                nodeCacheCapable: true
+                ignorable: true
+            EOF
+
+            echo "modifying kube-scheduler.yaml..."
+
+            if ! grep "^\  dnsPolicy: ClusterFirstWithHostNet" /etc/kubernetes/manifests/kube-scheduler.yaml; then
+                sed -i "/  hostNetwork: true/a \  dnsPolicy: ClusterFirstWithHostNet" /etc/kubernetes/manifests/kube-scheduler.yaml
+            fi
+
+            if ! grep "^\    - --config=*" /etc/kubernetes/manifests/kube-scheduler.yaml; then
+                sed -i "/    - --kubeconfig=/a \    - --config=/etc/kubernetes/kubeScheduler-config.yml" /etc/kubernetes/manifests/kube-scheduler.yaml
+            fi
+
+            if ! grep "^\      name: scheduler-config" /etc/kubernetes/manifests/kube-scheduler.yaml; then
+                sed -i "/    volumeMounts:/a \    - mountPath: /etc/kubernetes/kubeScheduler-config.yml\n      name: scheduler-config\n      readOnly: true" /etc/kubernetes/manifests/kube-scheduler.yaml
+                sed -i "/  volumes:/a \  - hostPath:\n      path: /etc/kubernetes/kubeScheduler-config.yml\n      type: File\n    name: scheduler-config" /etc/kubernetes/manifests/kube-scheduler.yaml
+            fi
+{{- else }}
+            set -ex
+            sleep 4
+            echo "generating scheduler-policy-config.json..."
             cat >/etc/kubernetes/scheduler-policy-config.json <<EOF
             {
             "kind" : "Policy",
@@ -67,21 +104,18 @@ spec:
             "hardPodAffinitySymmetricWeight" : 10
             }
             EOF
-
             echo "modifying kube-scheduler.yaml..."
-
             if ! grep "^\  dnsPolicy: ClusterFirstWithHostNet" /etc/kubernetes/manifests/kube-scheduler.yaml; then
                 sed -i "/  hostNetwork: true/a \  dnsPolicy: ClusterFirstWithHostNet" /etc/kubernetes/manifests/kube-scheduler.yaml
             fi
-
             if ! grep "^\    - --policy-config-file=*" /etc/kubernetes/manifests/kube-scheduler.yaml; then
                 sed -i "/    - --kubeconfig=/a \    - --policy-config-file=/etc/kubernetes/scheduler-policy-config.json" /etc/kubernetes/manifests/kube-scheduler.yaml
             fi
-
             if ! grep "^\      name: scheduler-policy-config" /etc/kubernetes/manifests/kube-scheduler.yaml; then
                 sed -i "/    volumeMounts:/a \    - mountPath: /etc/kubernetes/scheduler-policy-config.json\n      name: scheduler-policy-config\n      readOnly: true" /etc/kubernetes/manifests/kube-scheduler.yaml
                 sed -i "/  volumes:/a \  - hostPath:\n      path: /etc/kubernetes/scheduler-policy-config.json\n      type: File\n    name: scheduler-policy-config" /etc/kubernetes/manifests/kube-scheduler.yaml
             fi
+{{- end }}
         volumeMounts:
         - name: kube-dir
           mountPath: /etc/kubernetes/


### PR DESCRIPTION
cause:
```
k8s >= 1.23.x kube scheduler remove  policy config
see https://github.com/kubernetes/kubernetes/pull/105424
```
new scheduler config template:
```
https://v1-25.docs.kubernetes.io/zh-cn/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-Extender
```
Change
```
modify helm chart,automatic adaptation k8s version
```
test result:
![企业微信截图_c240ee6b-b934-4ab8-a3dc-3e09c9181ace](https://user-images.githubusercontent.com/24875266/228150455-972f4997-87e9-478c-a7fc-8613ad0b42b3.png)
![企业微信截图_21c69dd9-b35d-4d9c-9aff-0ad5c9f205ea](https://user-images.githubusercontent.com/24875266/228150641-7819c26e-5105-4395-984e-eddeab6e20e4.png)


