### PR TITLE
Ftr: add option of use node hostname dns to support edge scene

### DIFF
--- a/cmd/csi/csi.go
+++ b/cmd/csi/csi.go
@@ -89,7 +89,7 @@ func Start(opt *csiOption) error {
 		csi.WithSnapshotClient(snapClient),
 		csi.WithLocalClient(localclient),
 		csi.WithDriverMode(opt.DriverMode),
-		csi.WithUseNodeHostnameDNS(opt.UseNodeHostnameDNS),
+		csi.WithUseNodeHostname(opt.UseNodeHostname),
 	)
 	if err := driver.Run(); err != nil {
 		return err

--- a/cmd/csi/csi.go
+++ b/cmd/csi/csi.go
@@ -89,6 +89,7 @@ func Start(opt *csiOption) error {
 		csi.WithSnapshotClient(snapClient),
 		csi.WithLocalClient(localclient),
 		csi.WithDriverMode(opt.DriverMode),
+		csi.WithUseNodeHostnameDNS(opt.UseNodeHostnameDNS),
 	)
 	if err := driver.Run(); err != nil {
 		return err

--- a/cmd/csi/options.go
+++ b/cmd/csi/options.go
@@ -32,7 +32,7 @@ type csiOption struct {
 	LVMDPort                string
 	CgroupDriver            string
 	DriverMode              string
-	UseNodeHostnameDNS      bool
+	UseNodeHostname         bool
 	ExtenderSchedulerNames  []string
 	FrameworkSchedulerNames []string
 }
@@ -48,7 +48,7 @@ func (option *csiOption) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&option.LVMDPort, "lvmdPort", "1736", "Port of lvm daemon")
 	fs.StringVar(&option.CgroupDriver, "cgroupDriver", "systemd", "the name of cgroup driver")
 	fs.StringVar(&option.DriverMode, "driver-mode", "all", "driver mode")
-	fs.BoolVar(&option.UseNodeHostnameDNS, "use-node-hostname-dns", false, "use node hostname dns for grpc connection")
+	fs.BoolVar(&option.UseNodeHostname, "use-node-hostname", false, "use node hostname dns for grpc connection")
 	fs.StringSliceVar(&option.ExtenderSchedulerNames, "extender-scheduler-names", []string{"default-scheduler"}, "extender scheduler names")
 	fs.StringSliceVar(&option.FrameworkSchedulerNames, "framework-scheduler-names", []string{}, "framework scheduler names")
 }

--- a/cmd/csi/options.go
+++ b/cmd/csi/options.go
@@ -48,7 +48,7 @@ func (option *csiOption) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&option.LVMDPort, "lvmdPort", "1736", "Port of lvm daemon")
 	fs.StringVar(&option.CgroupDriver, "cgroupDriver", "systemd", "the name of cgroup driver")
 	fs.StringVar(&option.DriverMode, "driver-mode", "all", "driver mode")
-	fs.BoolVar(&option.UseNodeHostnameDNS, "use-node-hostname-dns", false, "driver mode")
+	fs.BoolVar(&option.UseNodeHostnameDNS, "use-node-hostname-dns", false, "use node hostname dns for grpc connection")
 	fs.StringSliceVar(&option.ExtenderSchedulerNames, "extender-scheduler-names", []string{"default-scheduler"}, "extender scheduler names")
 	fs.StringSliceVar(&option.FrameworkSchedulerNames, "framework-scheduler-names", []string{}, "framework scheduler names")
 }

--- a/cmd/csi/options.go
+++ b/cmd/csi/options.go
@@ -32,6 +32,7 @@ type csiOption struct {
 	LVMDPort                string
 	CgroupDriver            string
 	DriverMode              string
+	UseNodeHostnameDNS      bool
 	ExtenderSchedulerNames  []string
 	FrameworkSchedulerNames []string
 }
@@ -47,6 +48,7 @@ func (option *csiOption) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&option.LVMDPort, "lvmdPort", "1736", "Port of lvm daemon")
 	fs.StringVar(&option.CgroupDriver, "cgroupDriver", "systemd", "the name of cgroup driver")
 	fs.StringVar(&option.DriverMode, "driver-mode", "all", "driver mode")
+	fs.BoolVar(&option.UseNodeHostnameDNS, "use-node-hostname-dns", false, "driver mode")
 	fs.StringSliceVar(&option.ExtenderSchedulerNames, "extender-scheduler-names", []string{"default-scheduler"}, "extender scheduler names")
 	fs.StringSliceVar(&option.FrameworkSchedulerNames, "framework-scheduler-names", []string{}, "framework scheduler names")
 }

--- a/pkg/csi/controllerserver.go
+++ b/pkg/csi/controllerserver.go
@@ -18,7 +18,6 @@ package csi
 
 import (
 	"fmt"
-	"github.com/alibaba/open-local/pkg/csi/server"
 	"net"
 	"strconv"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	localtype "github.com/alibaba/open-local/pkg"
 	"github.com/alibaba/open-local/pkg/csi/adapter"
 	"github.com/alibaba/open-local/pkg/csi/client"
+	"github.com/alibaba/open-local/pkg/csi/server"
 	"github.com/alibaba/open-local/pkg/restic"
 	"github.com/alibaba/open-local/pkg/signals"
 	"github.com/alibaba/open-local/pkg/utils"

--- a/pkg/csi/controllerserver.go
+++ b/pkg/csi/controllerserver.go
@@ -18,6 +18,7 @@ package csi
 
 import (
 	"fmt"
+	"github.com/alibaba/open-local/pkg/csi/server"
 	"net"
 	"strconv"
 	"strings"
@@ -27,7 +28,6 @@ import (
 	localtype "github.com/alibaba/open-local/pkg"
 	"github.com/alibaba/open-local/pkg/csi/adapter"
 	"github.com/alibaba/open-local/pkg/csi/client"
-	"github.com/alibaba/open-local/pkg/csi/server"
 	"github.com/alibaba/open-local/pkg/restic"
 	"github.com/alibaba/open-local/pkg/signals"
 	"github.com/alibaba/open-local/pkg/utils"
@@ -767,7 +767,13 @@ func (cs *controllerServer) getNodeConn(nodeSelected string) (client.Connection,
 	if err != nil {
 		return nil, err
 	}
-	addr, err := getNodeAddr(node, nodeSelected)
+	var addr string
+	if cs.options.useNodeHostDNS {
+		addr = node.Name + ":" + server.GetLvmdPort()
+	} else {
+		addr, err = getNodeAddr(node, nodeSelected)
+	}
+
 	if err != nil {
 		log.Errorf("CreateVolume: Get node %s address with error: %s", nodeSelected, err.Error())
 		return nil, err

--- a/pkg/csi/controllerserver.go
+++ b/pkg/csi/controllerserver.go
@@ -767,12 +767,8 @@ func (cs *controllerServer) getNodeConn(nodeSelected string) (client.Connection,
 	if err != nil {
 		return nil, err
 	}
-	var addr string
-	if cs.options.useNodeHostDNS {
-		addr = node.Name + ":" + server.GetLvmdPort()
-	} else {
-		addr, err = getNodeAddr(node, nodeSelected)
-	}
+
+	addr, err := getNodeAddr(node, nodeSelected, cs.options.useNodeHostname)
 
 	if err != nil {
 		log.Errorf("CreateVolume: Get node %s address with error: %s", nodeSelected, err.Error())
@@ -782,7 +778,10 @@ func (cs *controllerServer) getNodeConn(nodeSelected string) (client.Connection,
 	return conn, err
 }
 
-func getNodeAddr(node *v1.Node, nodeID string) (string, error) {
+func getNodeAddr(node *v1.Node, nodeID string, useNodeHostname bool) (string, error) {
+	if useNodeHostname {
+		return node.Name + ":" + server.GetLvmdPort(), nil
+	}
 	ip, err := GetNodeIP(node, nodeID)
 	if err != nil {
 		return "", err

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -42,6 +42,7 @@ type driverOptions struct {
 	cgroupDriver            string
 	grpcConnectionTimeout   int
 	mode                    string
+	useNodeHostDNS          bool
 	extenderSchedulerNames  []string
 	frameworkSchedulerNames []string
 
@@ -55,6 +56,7 @@ var defaultDriverOptions = driverOptions{
 	cgroupDriver:            "systemd",
 	grpcConnectionTimeout:   DefaultConnectTimeout,
 	mode:                    "all",
+	useNodeHostDNS:          false,
 	extenderSchedulerNames:  []string{"default-scheduler"},
 	frameworkSchedulerNames: []string{},
 }
@@ -159,6 +161,12 @@ func WithGrpcConnectionTimeout(grpcConnectionTimeout int) Option {
 func WithDriverMode(mode string) Option {
 	return func(o *driverOptions) {
 		o.mode = mode
+	}
+}
+
+func WithUseNodeHostnameDNS(useNodeHostnameDNS bool) Option {
+	return func(o *driverOptions) {
+		o.useNodeHostDNS = useNodeHostnameDNS
 	}
 }
 

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -42,7 +42,7 @@ type driverOptions struct {
 	cgroupDriver            string
 	grpcConnectionTimeout   int
 	mode                    string
-	useNodeHostDNS          bool
+	useNodeHostname         bool
 	extenderSchedulerNames  []string
 	frameworkSchedulerNames []string
 
@@ -56,7 +56,7 @@ var defaultDriverOptions = driverOptions{
 	cgroupDriver:            "systemd",
 	grpcConnectionTimeout:   DefaultConnectTimeout,
 	mode:                    "all",
-	useNodeHostDNS:          false,
+	useNodeHostname:         false,
 	extenderSchedulerNames:  []string{"default-scheduler"},
 	frameworkSchedulerNames: []string{},
 }
@@ -164,9 +164,9 @@ func WithDriverMode(mode string) Option {
 	}
 }
 
-func WithUseNodeHostnameDNS(useNodeHostnameDNS bool) Option {
+func WithUseNodeHostname(useNodeHostname bool) Option {
 	return func(o *driverOptions) {
-		o.useNodeHostDNS = useNodeHostnameDNS
+		o.useNodeHostname = useNodeHostname
 	}
 }
 


### PR DESCRIPTION
In the edge computing scenario, we need to go through the cloud edge network proxy to access the specific port of the edge computing node, so I added a start option, `use-node-hostname-dns`, which defaults set to `false`, to enable the grpc call based on the hostname.

After this parameter is enabled, the machine will no longer based on an ip address to dial. Instead, the request for with dial to `${hostName}:${port}` will be made, for example, `my-edge-001-node:1736`. The domain name resolves the dns server configured during deployment to the proxy, which is applicable to the edge computing scenario where the network is visible in one direction.


在边缘计算场景下，我们需要通过云边网络代理，才能访问至边缘计算节点的特定端口，因此我增加了一个启动参数  `use-node-hostname-dns`， 默认为 `false`，用于开启基于主机名的grpc 调用。

启动这一参数后，位于中心侧的 csi-plugin 在建立grpc 链接之前，将不再基于机器ip进行调用，而是直接发起 ${hostName}:${port} 的请求，例如 my-edge-001-node:1736 。域名将被部署至集群时时配置的 dns 服务器解析至代理，从而适配于网络单向可见的边缘计算场景。