### PR TITLE
change node-role label selector

### DIFF
--- a/docs/api/nlsc_zh_CN.md
+++ b/docs/api/nlsc_zh_CN.md
@@ -30,7 +30,7 @@ spec:
   nodesConfig:      # 为 node label 满足表达式的特定节点进行初始化配置。该配置会覆盖默认配置globalConfig
   - selector:       # 筛选规则
       matchExpressions:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: In
         values:
         - ""

--- a/docs/user-guide/snapshot.md
+++ b/docs/user-guide/snapshot.md
@@ -150,7 +150,7 @@ spec:
                     values: ["nginx-lvm"]
               topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:
@@ -272,7 +272,7 @@ spec:
                     values: ["nginx-lvm"]
               topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/device/sts-block.yaml
+++ b/example/device/sts-block.yaml
@@ -40,7 +40,7 @@ spec:
         app: nginx-device
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/device/sts-fs.yaml
+++ b/example/device/sts-fs.yaml
@@ -40,7 +40,7 @@ spec:
         app: nginx-device
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/lvm/sts-block.yaml
+++ b/example/lvm/sts-block.yaml
@@ -40,7 +40,7 @@ spec:
         app: nginx-lvm-block
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/lvm/sts-io-throttling.yaml
+++ b/example/lvm/sts-io-throttling.yaml
@@ -40,7 +40,7 @@ spec:
         app: test-io-throttling
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/lvm/sts-minio.yaml
+++ b/example/lvm/sts-minio.yaml
@@ -49,7 +49,7 @@ spec:
       name: minio
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/lvm/sts-nginx-snap.yaml
+++ b/example/lvm/sts-nginx-snap.yaml
@@ -43,7 +43,7 @@ spec:
         app: nginx-lvm-snap
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/lvm/sts-nginx.yaml
+++ b/example/lvm/sts-nginx.yaml
@@ -39,7 +39,7 @@ spec:
         app: nginx-lvm
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/example/mountpoint/sts-nginx.yaml
+++ b/example/mountpoint/sts-nginx.yaml
@@ -39,7 +39,7 @@ spec:
         app: nginx-mountpoint
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -162,7 +162,7 @@ spec:
       serviceAccountName: {{ .Values.name }}
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
 {{- if eq .Values.agent.driverMode "node" }}

--- a/helm/templates/extender.yaml
+++ b/helm/templates/extender.yaml
@@ -20,13 +20,13 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -25,7 +25,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/master
+              - key: node-role.kubernetes.io/control-plane
                 operator: In
                 values:
                 - ""

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -159,7 +159,7 @@ func newNLSC(name string) *localv1alpha1.NodeLocalStorageInitConfig {
 				{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"node-role.kubernetes.io/master": "",
+							"node-role.kubernetes.io/control-plane": "",
 						},
 					},
 					ListConfig: localv1alpha1.ListConfig{
@@ -176,7 +176,7 @@ func newNLSC(name string) *localv1alpha1.NodeLocalStorageInitConfig {
 
 func newMasterNode(name string) *corev1.Node {
 	labels := map[string]string{
-		"node-role.kubernetes.io/master": "",
+		"node-role.kubernetes.io/control-plane": "",
 		"beta.kubernetes.io/os":          "linux",
 		"kubernetes.io/hostname":         name,
 	}


### PR DESCRIPTION
The label `node-role.kubernetes.io/master` is deprecated after kubernetes 1.18 by default.
change `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`

refer:
https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint

fix #215 