### PR TITLE
fix: node driver registrar socket path 

### DIFF
--- a/docs/user-guide/apiserver-network-proxy.md
+++ b/docs/user-guide/apiserver-network-proxy.md
@@ -9,7 +9,7 @@ the controller and node plugins to communicate with worker nodes. However, in
 some cases workers might be running at the edge, behind a NAT or other network
 constraints. There are platforms like OpenYurt and SuperEdge that offer proxy
 tunnels and various other edge solutions. With these, you might be interested in
-the [`--use-node-hostname`](/docs/commandline/open-local_csi.md) argument, which
+the [`--use-node-hostname`](../../docs/commandline/open-local_csi.md) argument, which
 will use the node host-name DNS, instead of its IP, for the gRPC connection.
 
 Konnectivity relies on an [`EgressSelectorConfiguration`](https://kubernetes.io/docs/reference/config-api/apiserver-config.v1alpha1/#apiserver-k8s-io-v1alpha1-EgressSelectorConfiguration)

--- a/helm/templates/agent.yaml
+++ b/helm/templates/agent.yaml
@@ -56,7 +56,7 @@ spec:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 200m
@@ -81,7 +81,7 @@ spec:
           mountPropagation: "Bidirectional"
       - name: driver-registrar
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.registrar.image }}:{{ .Values.images.registrar.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         args:
         - "--v=5"
         - "--csi-address=/csi/csi.sock"
@@ -113,7 +113,7 @@ spec:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         args:
         - csi
         - "--endpoint=$(CSI_ENDPOINT)"

--- a/helm/templates/agent.yaml
+++ b/helm/templates/agent.yaml
@@ -134,7 +134,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
-          value: unix://var/lib/kubelet/plugins/{{ .Values.driver }}/csi.sock
+          value: unix:/{{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}/csi.sock
         - name: TZ
           value: Asia/Shanghai
         - name: ISSUE_ORPHANED_POD
@@ -174,7 +174,7 @@ spec:
           name: directvolume
 {{- end }}
         - name: pods-mount-dir
-          mountPath: /var/lib/kubelet
+          mountPath: {{ .Values.agent.kubelet_dir }}
           mountPropagation: "Bidirectional"
         - mountPath: /dev
           mountPropagation: "HostToContainer"

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -26,7 +26,7 @@ spec:
         - --timeout=10m
         env:
         - name: ADDRESS
-          value: /var/lib/kubelet/plugins/{{ .Values.driver }}/csi.sock
+          value: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}/csi.sock
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.provisioner.image }}:{{ .Values.images.provisioner.tag }}
@@ -39,14 +39,14 @@ spec:
             cpu: 50m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/kubelet/plugins/{{ .Values.driver }}
+        - mountPath: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}
           name: socket-dir
       - name: csi-resizer
         args:
         - --csi-address=$(ADDRESS)
         env:
         - name: ADDRESS
-          value: /var/lib/kubelet/plugins/{{ .Values.driver }}/csi.sock
+          value: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}/csi.sock
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.resizer.image }}:{{ .Values.images.resizer.tag }}
@@ -59,7 +59,7 @@ spec:
             cpu: 50m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/kubelet/plugins/{{ .Values.driver }}
+        - mountPath: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}
           name: socket-dir
       - name: csi-snapshotter
         args:
@@ -67,7 +67,7 @@ spec:
         - --snapshot-name-prefix=snap
         env:
         - name: ADDRESS
-          value: /var/lib/kubelet/plugins/{{ .Values.driver }}/csi.sock
+          value: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}/csi.sock
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.snapshotter.image }}:{{ .Values.images.snapshotter.tag }}
@@ -80,7 +80,7 @@ spec:
             cpu: 50m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/kubelet/plugins/{{ .Values.driver }}
+        - mountPath: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}
           name: socket-dir
 {{- if eq .Values.agent.driverMode "node" }}
       - name: csi-plugin
@@ -100,7 +100,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
-          value: unix://var/lib/kubelet/plugins/{{ .Values.driver }}/csi.sock
+          value: unix:/{{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}/csi.sock
         - name: TZ
           value: Asia/Shanghai
         - name: ISSUE_ORPHANED_POD
@@ -123,7 +123,7 @@ spec:
             cpu: 50m
             memory: 128Mi
         volumeMounts:
-        - mountPath: /var/lib/kubelet/plugins/{{ .Values.driver }}
+        - mountPath: {{ .Values.agent.kubelet_dir }}/plugins/{{ .Values.driver }}
           name: socket-dir
 {{- end }}
       - name: controller

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -30,7 +30,7 @@ spec:
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.provisioner.image }}:{{ .Values.images.provisioner.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 500m
@@ -50,7 +50,7 @@ spec:
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.resizer.image }}:{{ .Values.images.resizer.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 500m
@@ -71,7 +71,7 @@ spec:
         - name: TZ
           value: Asia/Shanghai
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.snapshotter.image }}:{{ .Values.images.snapshotter.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 500m
@@ -114,7 +114,7 @@ spec:
           value: "{{ .Values.global.YodaSchedulerSvcIP }}"
 {{- end }}
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 500m
@@ -132,7 +132,7 @@ spec:
         - --initconfig={{ .Values.name }}
         - --feature-gates=UpdateNLS={{ .Values.controller.update_nls }}
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 200m
@@ -148,7 +148,7 @@ spec:
         env:
           - name: TZ
             value: Asia/Shanghai
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         resources:
           limits:
             cpu: 500m

--- a/helm/templates/extender.yaml
+++ b/helm/templates/extender.yaml
@@ -43,7 +43,7 @@ spec:
         - --port={{ .Values.extender.port }}
         - --scheduler-strategy={{ .Values.extender.strategy }}
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         name: {{ .Values.name }}-scheduler-extender
         resources:
           limits:

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -41,6 +41,7 @@ spec:
       containers:
       - name: init
         image: {{ .Values.global.RegistryURL }}/{{ .Values.images.local.image }}:{{ .Values.images.local.tag }}
+        imagePullPolicy: {{ .Values.global.ImagePullPolicy }}
         command:
         - sh
         - "-c"

--- a/helm/values-acka.yaml
+++ b/helm/values-acka.yaml
@@ -56,3 +56,4 @@ global:
   YodaSchedulerSvcIP: 10.96.0.4
   RegistryURL: ack-agility-registry.cn-shanghai.cr.aliyuncs.com
   NumOfMasters: 3
+  ImagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -61,3 +61,4 @@ monitor:
   namespace: monitoring
 global:
   RegistryURL: ack-agility-registry.cn-shanghai.cr.aliyuncs.com
+  ImagePullPolicy: Always


### PR DESCRIPTION
The current implementation doesn't respect `.Values.agent.kubelet_dir` and doesn't work in case kubelet uses a non-default directory.

uses `/apps/data/kubelet` instead of `/var/lib/kubelet`

## logs

```
E0914 11:29:09.031771  246315 nestedpendingoperations.go:301] Operation for "{volumeName:kubernetes.io/csi/local.csi.aliyun.com^local-b6daea4e-222a-42d9-9a1c-c998ea8452df podName: nodeName:}" failed. No retries permitted until 2023-09-14 11:31:11.031748089 +0800 CST m=+75524.201713195 (durationBeforeRetry 2m2s). Error: "MountVolume.SetUp failed for volume \"local-b6daea4e-222a-42d9-9a1c-c998ea8452df\" (UniqueName: \"kubernetes.io/csi/local.csi.aliyun.com^local-b6daea4e-222a-42d9-9a1c-c998ea8452df\") pod \"rabbitmq-server-0\" (UID: \"c09c52b8-22c3-48ea-9954-7da39aae39f6\") : applyFSGroup failed for vol local-b6daea4e-222a-42d9-9a1c-c998ea8452df: lstat /apps/data/kubelet/pods/c09c52b8-22c3-48ea-9954-7da39aae39f6/volumes/kubernetes.io~csi/local-b6daea4e-222a-42d9-9a1c-c998ea8452df/mount: no such file or directory"
```

/kind feature
Add global imagePullPolicy configure