### PR TITLE
add MaxVolumesPerNode setting

### DIFF
--- a/helm/templates/agent.yaml
+++ b/helm/templates/agent.yaml
@@ -143,6 +143,8 @@ spec:
           value: "true"
         - name: ISSUE_MESSAGE_FILE
           value: "true"
+        - name: MAX_VOLUMES_PERNODE
+          value: "{{ .Values.agent.max_volumes_pre_node }}"
 {{- if .Values.global.YodaSchedulerSvcIP }}
         - name: EXTENDER_SVC_IP
           value: "{{ .Values.global.YodaSchedulerSvcIP }}"

--- a/helm/values-acka.yaml
+++ b/helm/values-acka.yaml
@@ -27,6 +27,7 @@ agent:
   volume_name_prefix: yoda
   spdk: false
   driverMode: node
+  max_volumes_pre_node: 256
 extender:
   name: yoda-scheduler-extender
   # scheduling strategy: binpack/spread

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,6 +33,7 @@ agent:
   # all: agent will start as csi controller and csi node
   # node: agent will start as csi node
   driverMode: node
+  max_volumes_pre_node: 256
 extender:
   name: open-local-scheduler-extender
   # scheduling strategy: binpack/spread

--- a/pkg/csi/nodeserver.go
+++ b/pkg/csi/nodeserver.go
@@ -59,15 +59,15 @@ type nodeServer struct {
 }
 
 func newNodeServer(options *driverOptions) *nodeServer {
-	var maxVolumesNum int64 = MaxVolumesPerNode
+	var maxVolumesNum int64 = DefaultMaxVolumesPerNode
 	volumeNum := os.Getenv("MAX_VOLUMES_PERNODE")
 	if volumeNum != "" {
 		num, err := strconv.ParseInt(volumeNum, 10, 64)
 		if err != nil {
 			log.Fatalf("NewNodeServer: MAX_VOLUMES_PERNODE must be int64, but get: %s", volumeNum)
 		} else {
-			if num < 0 || num > maxVolumesNum {
-				log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-%d, but get: %s", maxVolumesNum, volumeNum)
+			if num < 0 || num > int64(MaxVolumesPerNodeLimited) {
+				log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-%d, but get: %s", int64(MaxVolumesPerNodeLimited), volumeNum)
 			} else {
 				maxVolumesNum = num
 				log.Infof("NewNodeServer: MAX_VOLUMES_PERNODE is set to(not default): %d", maxVolumesNum)

--- a/pkg/csi/nodeserver.go
+++ b/pkg/csi/nodeserver.go
@@ -53,11 +53,28 @@ type nodeServer struct {
 	spdkSupported        bool
 	spdkclient           *spdk.SpdkClient
 	osTool               OSTool
+	maxVolumesPerNode    int64
 
 	options *driverOptions
 }
 
 func newNodeServer(options *driverOptions) *nodeServer {
+	var maxVolumesNum int64 = MaxVolumesPerNode
+	volumeNum := os.Getenv("MAX_VOLUMES_PERNODE")
+	if volumeNum != "" {
+		num, err := strconv.ParseInt(volumeNum, 10, 64)
+		if err != nil {
+			log.Fatalf("NewNodeServer: MAX_VOLUMES_PERNODE must be int64, but get: %s", volumeNum)
+		} else {
+			if num < 0 || num > maxVolumesNum {
+				log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-15, but get: %s", volumeNum)
+			} else {
+				maxVolumesNum = num
+				log.Infof("NewNodeServer: MAX_VOLUMES_PERNODE is set to(not default): %d", maxVolumesNum)
+			}
+		}
+	}
+
 	store, err := NewVolumeStore(DefaultEphemeralVolumeDataFilePath)
 	if err != nil {
 		log.Fatalf("fail to initialize ephemeral volume store: %s", err.Error())
@@ -73,6 +90,7 @@ func newNodeServer(options *driverOptions) *nodeServer {
 		spdkSupported:        false,
 		osTool:               NewOSTool(),
 		options:              options,
+		maxVolumesPerNode:    maxVolumesNum,
 	}
 
 	if options.enableSpdk {
@@ -306,6 +324,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 				pkg.KubernetesNodeIdentityKey: ns.options.nodeID,
 			},
 		},
+		MaxVolumesPerNode: ns.maxVolumesPerNode,
 	}, nil
 }
 

--- a/pkg/csi/nodeserver.go
+++ b/pkg/csi/nodeserver.go
@@ -67,7 +67,7 @@ func newNodeServer(options *driverOptions) *nodeServer {
 			log.Fatalf("NewNodeServer: MAX_VOLUMES_PERNODE must be int64, but get: %s", volumeNum)
 		} else {
 			if num < 0 || num > maxVolumesNum {
-				log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-15, but get: %s", volumeNum)
+				log.Errorf("NewNodeServer: MAX_VOLUMES_PERNODE must between 0-%d, but get: %s", maxVolumesNum, volumeNum)
 			} else {
 				maxVolumesNum = num
 				log.Infof("NewNodeServer: MAX_VOLUMES_PERNODE is set to(not default): %d", maxVolumesNum)

--- a/pkg/csi/type.go
+++ b/pkg/csi/type.go
@@ -56,8 +56,10 @@ const (
 	DirectTag = "direct"
 	// StripingType striping type
 	StripingType = "striping"
-	// MaxVolumesPerNode define max volumes one node
-	MaxVolumesPerNode = 64
+	// DefaultMaxVolumesPerNode define default max volumes one node
+	DefaultMaxVolumesPerNode = 64
+	// MaxVolumesPerNodeLimited define limit max volumes one node
+	MaxVolumesPerNodeLimited = 1024
 )
 
 type CSIPlugin struct {

--- a/pkg/csi/type.go
+++ b/pkg/csi/type.go
@@ -56,7 +56,7 @@ const (
 	DirectTag = "direct"
 	// StripingType striping type
 	StripingType = "striping"
-	// MaxVolumesPerNode define max ebs one node
+	// MaxVolumesPerNode define max volumes one node
 	MaxVolumesPerNode = 64
 )
 

--- a/pkg/csi/type.go
+++ b/pkg/csi/type.go
@@ -56,6 +56,8 @@ const (
 	DirectTag = "direct"
 	// StripingType striping type
 	StripingType = "striping"
+	// MaxVolumesPerNode define max ebs one node
+	MaxVolumesPerNode = 64
 )
 
 type CSIPlugin struct {


### PR DESCRIPTION
This PR adds support for returning max volume limit in CSI NodeGetInfo call, It returns MaxVolumesPerNode in CSINodeGetInfo response, which defaults to 64, This can be configured via `MAX_VOLUMES_PERNODE` from ENV config.