### PR TITLE
在大规模场景下，降低agent对apiserver的访问压力

### DIFF
--- a/pkg/agent/discovery/discovery_test.go
+++ b/pkg/agent/discovery/discovery_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package discovery
 
 import (
+	localv1alpha1 "github.com/alibaba/open-local/pkg/apis/storage/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"time"
 )
 
 func TestFilterInfo(t *testing.T) {
@@ -80,4 +83,117 @@ func sameStringSlice(x, y []string) bool {
 		}
 	}
 	return len(diff) == 0
+}
+
+func TestIsNlsStatusChanged(t *testing.T) {
+	type args struct {
+		oldStatus *localv1alpha1.NodeLocalStorageStatus
+		newStatus *localv1alpha1.NodeLocalStorageStatus
+	}
+	updatedTime := metav1.Now()
+	oldStatus := &localv1alpha1.NodeLocalStorageStatus{
+		NodeStorageInfo: localv1alpha1.NodeStorageInfo{
+			DeviceInfos: []localv1alpha1.DeviceInfo{
+				{
+					Name: "/dev/sdb",
+					MediaType: "hdd",
+					Total: 100000000,
+				},
+			},
+			VolumeGroups: []localv1alpha1.VolumeGroup{
+				{
+					Name: "pool0",
+					PhysicalVolumes: []string{
+						"/dev/sdb",
+					},
+					Total: 100000000,
+					Allocatable: 100000000,
+					Available: 100000000,
+				},
+			},
+			Phase: "Running",
+			State: localv1alpha1.StorageState{
+				Status: localv1alpha1.ConditionTrue,
+				Type: localv1alpha1.StorageReady,
+			},
+		},
+		FilteredStorageInfo: localv1alpha1.FilteredStorageInfo{
+			UpdateStatus: localv1alpha1.UpdateStatusInfo{
+				LastUpdateTime: &updatedTime,
+				Status: "accepted",
+			},
+			VolumeGroups: []string{"pool0"},
+		},
+	}
+
+	newStatus := &localv1alpha1.NodeLocalStorageStatus{
+		NodeStorageInfo: localv1alpha1.NodeStorageInfo{
+			DeviceInfos: []localv1alpha1.DeviceInfo{
+				{
+					Name: "/dev/sdb",
+					MediaType: "hdd",
+					Total: 100000000,
+				},
+			},
+			VolumeGroups: []localv1alpha1.VolumeGroup{
+				{
+					Name: "pool0",
+					PhysicalVolumes: []string{
+						"/dev/sdb",
+					},
+					Total: 100000000,
+					Allocatable: 50000000,  // changed
+					Available: 50000000,    // changed
+				},
+			},
+			Phase: "Running",
+			State: localv1alpha1.StorageState{
+				Status: localv1alpha1.ConditionTrue,
+				Type: localv1alpha1.StorageReady,
+			},
+		},
+		FilteredStorageInfo: localv1alpha1.FilteredStorageInfo{
+			UpdateStatus: localv1alpha1.UpdateStatusInfo{
+				LastUpdateTime: &updatedTime,
+				Status: "accepted",
+			},
+			VolumeGroups: []string{"pool0"},
+		},
+	}
+
+	newStatusOnlyTimeChanged := oldStatus
+	newUpdateTime := updatedTime.Add(1*time.Minute)
+	newStatusOnlyTimeChanged.FilteredStorageInfo.UpdateStatus.LastUpdateTime = &metav1.Time{Time: newUpdateTime}
+	newStatusOnlyTimeChanged.NodeStorageInfo.State.LastTransitionTime = &metav1.Time{Time: newUpdateTime}
+	newStatusOnlyTimeChanged.NodeStorageInfo.State.LastHeartbeatTime = &metav1.Time{Time: newUpdateTime}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				oldStatus: oldStatus,
+				newStatus: newStatus,
+			},
+			want: true,
+		},
+		{
+			name: "test2",
+			args: args{
+				oldStatus: oldStatus,
+				newStatus: newStatusOnlyTimeChanged,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNlsStatusChanged(tt.args.oldStatus, tt.args.newStatus); got != tt.want {
+				t.Errorf("isNlsStatusChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/csi/nodeserver.go
+++ b/pkg/csi/nodeserver.go
@@ -723,6 +723,6 @@ func (ns *nodeServer) checkSPDKSupport() {
 			}
 		}
 
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Second * 5)
 	}
 }


### PR DESCRIPTION
【背景问题】
在大规模集群场景下，发现agent对apiserver的压力很大。通过分析发现，主要源于两处：
1. agent会不停的访问apiserver读取NodeLocalStorage，检测spdk配置，间隔只有100ms，因而对apiserver的访问频率 = 10 * N / s（N为节点数）
2. agent会定时上报节点的NodeLocalStorage状态，无论NodeLocalStorage状态是否变化都会上报，上报周期是60s
其中，问题1是主要压力来源

【解决思路】
1. 降低访问频率，不需要100ms这么频繁访问
2. 只在NodeLocalStorage发生变化时才上报，因为大部分时间是没有变化的，不需要上报